### PR TITLE
change fuse to fuser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,16 +186,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuse"
-version = "0.3.1"
+name = "fuser"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e57070510966bfef93662a81cb8aa2b1c7db0964354fa9921434f04b9e8660"
+checksum = "5910691a0ececcc6eba8bb14029025c2d123e96a53db1533f6a4602861a5aaf7"
 dependencies = [
  "libc",
- "log 0.3.9",
+ "log",
+ "memchr",
+ "page_size",
  "pkg-config",
- "thread-scoped",
- "time",
+ "smallvec",
+ "users",
+ "zerocopy",
 ]
 
 [[package]]
@@ -284,19 +293,10 @@ dependencies = [
  "aes",
  "byte_struct",
  "cmac",
- "log 0.4.17",
+ "log",
  "lru",
  "rand",
  "sha2",
-]
-
-[[package]]
-name = "log"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-dependencies = [
- "log 0.4.17",
 ]
 
 [[package]]
@@ -316,6 +316,12 @@ checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
  "hashbrown",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "num-integer"
@@ -341,6 +347,16 @@ name = "once_cell"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+
+[[package]]
+name = "page_size"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "pkg-config"
@@ -424,7 +440,7 @@ dependencies = [
 name = "save3ds_fuse"
 version = "0.1.0"
 dependencies = [
- "fuse",
+ "fuser",
  "getopts",
  "libc",
  "libsave3ds",
@@ -444,6 +460,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
 name = "stderrlog"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,7 +473,7 @@ checksum = "af95cb8a5f79db5b2af2a46f44da7594b5adbcbb65cbf87b8da0959bfdd82460"
 dependencies = [
  "atty",
  "chrono",
- "log 0.4.17",
+ "log",
  "termcolor",
  "thread_local",
 ]
@@ -492,12 +514,6 @@ checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "thread-scoped"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbb6aa301e5d3b0b5ef639c9a9c7e2f1c944f177b460c04dc24c69b1fa2bd99"
 
 [[package]]
 name = "thread_local"
@@ -544,6 +560,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
+name = "users"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
+dependencies = [
+ "libc",
+ "log",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,7 +604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
 dependencies = [
  "bumpalo",
- "log 0.4.17",
+ "log",
  "once_cell",
  "proc-macro2 1.0.43",
  "quote 1.0.21",
@@ -645,3 +671,24 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "zerocopy"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332f188cc1bcf1fe1064b8c58d150f497e697f49774aa846f2dc949d9a25f236"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6505e6815af7de1746a08f69c69606bb45695a17149517680f3b2149713b19a3"
+dependencies = [
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
+]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Note that the supported NAND format is in unpacked cleartext filesystem. If you 
  1. install pkg-config and FUSE library.
    - Debian: `sudo apt-get install libfuse-dev pkg-config`
    - CentOS: `sudo yum install fuse-devel pkgconfig`
-   - macOS: `brew cask install osxfuse && brew install pkg-config`
+   - macOS: `brew install macfuse --cask`
    - FreeBSD: `pkg install fusefs-libs pkgconf`
  2.
  ```

--- a/save3ds_fuse/Cargo.toml
+++ b/save3ds_fuse/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [features]
 default = ["unixfuse"]
-unixfuse = ["libc", "fuse", "time"]
+unixfuse = ["libc",  "time", "fuser"]
 
 [dependencies]
 libsave3ds = { path = "../libsave3ds" }
@@ -15,5 +15,5 @@ stderrlog = "0.5"
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2", optional = true }
-fuse = { version = "0.3.1", optional = true }
+fuser = { version = "0.12.0", optional = true }
 time = { version = "0.1.42", optional = true }

--- a/save3ds_fuse/src/main.rs
+++ b/save3ds_fuse/src/main.rs
@@ -429,7 +429,7 @@ where
                     };
 
                     reply.entry(
-                        &Duration::new(0, 1),
+                        &Duration::new(1, 0),
                         &make_dir_attr(
                             self.read_only,
                             self.uid,
@@ -1416,8 +1416,7 @@ fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
             resource.open_bare_save(&bare, !read_only)?,
             operation,
             mountpoint,
-        )
-        .unwrap()
+        )?
     } else if let Some(id) = nand_save_id {
         let id = u32::from_str_radix(&id, 16)?;
         if let Some(format_param) = format_param {

--- a/save3ds_fuse/src/main.rs
+++ b/save3ds_fuse/src/main.rs
@@ -222,7 +222,6 @@ where
     println!("Clearing the original contents...");
     let root = save.open_root()?;
     clear_impl(&save, &root)?;
-    clear_impl(&save, &root)?;
     println!("Importing new contents...");
     import_impl(&save, &root, mountpoint)?;
     save.commit()?;
@@ -443,7 +442,7 @@ where
                 }
                 if let Ok(child) = parent_dir.open_sub_file(name_converted) {
                     reply.entry(
-                        &Duration::new(0, 1),
+                        &Duration::new(1, 0),
                         &make_file_attr(
                             self.read_only,
                             self.uid,
@@ -1430,8 +1429,7 @@ fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
             resource.open_nand_save(id, !read_only)?,
             operation,
             mountpoint,
-        )
-        .unwrap()
+        )?
     } else if let Some(id) = sd_save_id {
         let id = u64::from_str_radix(&id, 16)?;
         if let Some(format_param) = format_param {
@@ -1445,8 +1443,7 @@ fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
             resource.open_sd_save(id, !read_only)?,
             operation,
             mountpoint,
-        )
-        .unwrap()
+        )?
     } else if let Some(id) = sd_ext_id {
         let id = u64::from_str_radix(&id, 16)?;
         if let Some(format_param) = format_param {
@@ -1456,7 +1453,7 @@ fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
             println!("Formatting done");
         }
 
-        start(resource.open_sd_ext(id, !read_only)?, operation, mountpoint).unwrap()
+        start(resource.open_sd_ext(id, !read_only)?, operation, mountpoint)?
     } else if let Some(id) = nand_ext_id {
         let id = u64::from_str_radix(&id, 16)?;
         if let Some(format_param) = format_param {
@@ -1470,8 +1467,7 @@ fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
             resource.open_nand_ext(id, !read_only)?,
             operation,
             mountpoint,
-        )
-        .unwrap()
+        )?
     } else if let Some(db_type) = db_type {
         if format_param.is_some() {
             println!("Warning: formatting not supported");
@@ -1494,8 +1490,7 @@ fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
             resource.open_db(db_type, !read_only)?,
             operation,
             mountpoint,
-        )
-        .unwrap()
+        )?
     } else if let Some(cart) = cart_path {
         if let Some(format_param) = format_param {
             println!("Formatting...");
@@ -1507,8 +1502,7 @@ fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
             resource.open_cart_save(&cart, !read_only)?,
             operation,
             mountpoint,
-        )
-        .unwrap()
+        )?
     } else {
         panic!()
     };


### PR DESCRIPTION
The previously used [fuse-rs](https://github.com/zargony/fuse-rs) is no longer maintained. Use [fuser](https://crates.io/crates/fuser) instead of fuse.